### PR TITLE
feat: WASD + camera-relative keyboard movement

### DIFF
--- a/components/game/KeyboardInput.tsx
+++ b/components/game/KeyboardInput.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useFrame, useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+import { useGameStore } from '@/store/gameStore'
+
+const SPEED = 5          // units per second
+const BOUNDS = 17        // ±17 units
+
+const KEYS: Record<string, [number, number]> = {
+  KeyW: [0, -1], ArrowUp: [0, -1],
+  KeyS: [0,  1], ArrowDown: [0,  1],
+  KeyA: [-1, 0], ArrowLeft: [-1, 0],
+  KeyD: [1,  0], ArrowRight: [1,  0],
+}
+
+export default function KeyboardInput() {
+  const held = useRef<Set<string>>(new Set())
+  const setPlayerTarget = useGameStore((s) => s.setPlayerTarget)
+  const { camera } = useThree()
+
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (KEYS[e.code]) { e.preventDefault(); held.current.add(e.code) }
+    }
+    const up = (e: KeyboardEvent) => held.current.delete(e.code)
+    window.addEventListener('keydown', down)
+    window.addEventListener('keyup', up)
+    return () => {
+      window.removeEventListener('keydown', down)
+      window.removeEventListener('keyup', up)
+    }
+  }, [])
+
+  useFrame((_, delta) => {
+    if (held.current.size === 0) return
+
+    // Compute camera's horizontal forward/right vectors (projected onto XZ plane)
+    const forward = new THREE.Vector3()
+    camera.getWorldDirection(forward)
+    forward.y = 0
+    forward.normalize()
+
+    const right = new THREE.Vector3()
+    right.crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize()
+
+    let mx = 0
+    let mz = 0
+    for (const code of held.current) {
+      const dir = KEYS[code]
+      if (!dir) continue
+      // dir[0] = local X (right), dir[1] = local Z (forward)
+      mx += right.x * dir[0] + forward.x * dir[1]
+      mz += right.z * dir[0] + forward.z * dir[1]
+    }
+
+    if (mx === 0 && mz === 0) return
+
+    // Normalise so diagonals aren't faster
+    const len = Math.sqrt(mx * mx + mz * mz)
+    const step = (SPEED * delta) / len
+
+    const store = useGameStore.getState()
+    const nx = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetX + mx * step))
+    const nz = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetZ + mz * step))
+    setPlayerTarget(nx, nz)
+  })
+
+  return null
+}

--- a/components/game/Room.tsx
+++ b/components/game/Room.tsx
@@ -7,6 +7,7 @@ import BeachRoom from '@/components/rooms/BeachRoom'
 import LibraryRoom from '@/components/rooms/LibraryRoom'
 import ClaudeOrb from './ClaudeOrb'
 import NPCManager from './NPCManager'
+import KeyboardInput from './KeyboardInput'
 
 const ROOM_COMPONENTS = {
   plaza: PlazaRoom,
@@ -28,6 +29,7 @@ export default function Room() {
 
   return (
     <>
+      <KeyboardInput />
       <RoomComponent />
       <NPCManager />
       <ClaudeOrb


### PR DESCRIPTION
## Summary
- Adds `KeyboardInput` component that reads held keys each frame inside the R3F canvas
- WASD / arrow keys move the player in camera-relative directions (W = into screen, regardless of orbit angle)
- Diagonal movement normalised so speed is consistent
- Bounds clamped to ±17 to match upcoming larger maps (#4)
- Click-to-walk still works — both inputs write to the same `playerTargetX/Z`

## Test plan
- [ ] W/S move forward/backward relative to camera facing
- [ ] A/D strafe left/right relative to camera
- [ ] Rotating camera with left-drag and then moving with WASD feels correct
- [ ] Diagonal (W+D) moves at same speed as cardinal
- [ ] Click-to-walk still works alongside keyboard
- [ ] Player cannot walk outside ±17 bounds

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)