### PR TITLE
fix: camera follows player

### DIFF
--- a/components/game/GameCanvas.tsx
+++ b/components/game/GameCanvas.tsx
@@ -1,11 +1,47 @@
 'use client'
 
-import { Canvas } from '@react-three/fiber'
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
-import { Suspense } from 'react'
+import { Suspense, useRef } from 'react'
+import * as THREE from 'three'
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import Room from './Room'
 import HUD from './HUD'
+import { useGameStore } from '@/store/gameStore'
+
+function CameraRig() {
+  const controlsRef = useRef<OrbitControlsImpl>(null)
+  const smoothTarget = useRef(new THREE.Vector3(0, 0.8, 0))
+  const { camera } = useThree()
+
+  useFrame(() => {
+    if (!controlsRef.current) return
+    const { playerX, playerZ } = useGameStore.getState()
+    const dest = new THREE.Vector3(playerX, 0.8, playerZ)
+    smoothTarget.current.lerp(dest, 0.08)
+    const prevTarget = controlsRef.current.target.clone()
+    const delta = smoothTarget.current.clone().sub(prevTarget)
+    controlsRef.current.target.copy(smoothTarget.current)
+    camera.position.add(delta)
+    controlsRef.current.update()
+  })
+
+  return (
+    <OrbitControls
+      ref={controlsRef}
+      enablePan={false}
+      enableDamping
+      dampingFactor={0.06}
+      minPolarAngle={Math.PI / 9}
+      maxPolarAngle={Math.PI / 2.8}
+      minDistance={8}
+      maxDistance={55}
+      rotateSpeed={0.6}
+      zoomSpeed={0.8}
+    />
+  )
+}
 
 export default function GameCanvas() {
   return (
@@ -16,18 +52,7 @@ export default function GameCanvas() {
         camera={{ position: [16, 13, 16], fov: 42, near: 0.1, far: 300 }}
         onCreated={({ camera }) => camera.lookAt(0, 0, 0)}
       >
-        <OrbitControls
-          enablePan={false}
-          enableDamping
-          dampingFactor={0.06}
-          minPolarAngle={Math.PI / 9}
-          maxPolarAngle={Math.PI / 2.8}
-          minDistance={8}
-          maxDistance={55}
-          rotateSpeed={0.6}
-          zoomSpeed={0.8}
-          target={[0, 0, 0]}
-        />
+        <CameraRig />
         <ambientLight intensity={0.4} />
         <directionalLight position={[8, 16, 8]} intensity={0.7} />
         <Suspense fallback={null}>


### PR DESCRIPTION
## Summary
- Replaced static `OrbitControls` with a `CameraRig` component
- `useFrame` reads `playerX/Z` from the Zustand store each frame
- Smoothly lerps the OrbitControls target and shifts the camera position by the same delta
- Player stays centred in view while still allowing free orbit/zoom

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)