### PR TITLE
feat: collision system — characters can't walk through objects

### DIFF
--- a/components/game/GroundPlane.tsx
+++ b/components/game/GroundPlane.tsx
@@ -3,6 +3,8 @@
 import { useRef } from 'react'
 import * as THREE from 'three'
 import { useGameStore } from '@/store/gameStore'
+import { ROOMS } from '@/lib/roomConfig'
+import { resolvePosition } from '@/lib/collision'
 
 // Invisible horizontal plane — click to walk in XZ
 export default function GroundPlane() {
@@ -11,9 +13,11 @@ export default function GroundPlane() {
 
   function handleClick(e: { point: THREE.Vector3; stopPropagation: () => void }) {
     e.stopPropagation()
-    const targetX = Math.max(-17, Math.min(17, e.point.x))
-    const targetZ = Math.max(-17, Math.min(17, e.point.z))
-    setPlayerTarget(targetX, targetZ)
+    let x = Math.max(-17, Math.min(17, e.point.x))
+    let z = Math.max(-17, Math.min(17, e.point.z))
+    const { currentRoom } = useGameStore.getState()
+    ;[x, z] = resolvePosition(x, z, ROOMS[currentRoom].colliders)
+    setPlayerTarget(x, z)
   }
 
   return (

--- a/components/game/KeyboardInput.tsx
+++ b/components/game/KeyboardInput.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import * as THREE from 'three'
 import { useGameStore } from '@/store/gameStore'
+import { ROOMS } from '@/lib/roomConfig'
+import { resolvePosition } from '@/lib/collision'
 
 const SPEED = 5          // units per second
 const BOUNDS = 17        // ±17 units
@@ -62,8 +64,9 @@ export default function KeyboardInput() {
     const step = (SPEED * delta) / len
 
     const store = useGameStore.getState()
-    const nx = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetX + mx * step))
-    const nz = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetZ + mz * step))
+    let nx = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetX + mx * step))
+    let nz = Math.max(-BOUNDS, Math.min(BOUNDS, store.playerTargetZ + mz * step))
+    ;[nx, nz] = resolvePosition(nx, nz, ROOMS[store.currentRoom].colliders)
     setPlayerTarget(nx, nz)
   })
 

--- a/lib/collision.ts
+++ b/lib/collision.ts
@@ -1,0 +1,44 @@
+export interface Collider {
+  cx: number  // center X
+  cz: number  // center Z
+  hw: number  // half-width  (X axis)
+  hd: number  // half-depth  (Z axis)
+}
+
+/** Character footprint radius in world units */
+export const CHAR_RADIUS = 0.38
+
+/** Resolve a circle at (x, z) out of one AABB collider. */
+function resolveOne(x: number, z: number, c: Collider): [number, number] {
+  // Nearest point on AABB to circle centre
+  const nearX = Math.max(c.cx - c.hw, Math.min(c.cx + c.hw, x))
+  const nearZ = Math.max(c.cz - c.hd, Math.min(c.cz + c.hd, z))
+  const dx = x - nearX
+  const dz = z - nearZ
+  const distSq = dx * dx + dz * dz
+
+  if (distSq >= CHAR_RADIUS * CHAR_RADIUS) return [x, z]   // no overlap
+
+  if (distSq < 0.00001) {
+    // Centre is inside AABB — push out on the shortest-overlap axis
+    const overlapX = c.hw + CHAR_RADIUS - Math.abs(x - c.cx)
+    const overlapZ = c.hd + CHAR_RADIUS - Math.abs(z - c.cz)
+    if (overlapX < overlapZ) {
+      return [c.cx + (x >= c.cx ? c.hw + CHAR_RADIUS : -(c.hw + CHAR_RADIUS)), z]
+    }
+    return [x, c.cz + (z >= c.cz ? c.hd + CHAR_RADIUS : -(c.hd + CHAR_RADIUS))]
+  }
+
+  // Push circle to just touch the AABB surface
+  const dist = Math.sqrt(distSq)
+  return [nearX + (dx / dist) * CHAR_RADIUS, nearZ + (dz / dist) * CHAR_RADIUS]
+}
+
+/** Iteratively resolve (x, z) against all colliders and return a safe position. */
+export function resolvePosition(x: number, z: number, colliders: Collider[]): [number, number] {
+  let rx = x, rz = z
+  for (const c of colliders) {
+    ;[rx, rz] = resolveOne(rx, rz, c)
+  }
+  return [rx, rz]
+}

--- a/lib/roomConfig.ts
+++ b/lib/roomConfig.ts
@@ -1,3 +1,5 @@
+import type { Collider } from './collision'
+
 export type RoomId = 'plaza' | 'cafe' | 'beach' | 'library'
 
 export interface Door {
@@ -17,6 +19,7 @@ export interface RoomConfig {
   doors: Door[]
   npcCount: number
   npcColors: string[]
+  colliders: Collider[]
 }
 
 export const ROOMS: Record<RoomId, RoomConfig> = {
@@ -33,6 +36,28 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     ],
     npcCount: 5,
     npcColors: ['#7c3aed', '#059669', '#0ea5e9', '#f59e0b', '#ec4899'],
+    colliders: [
+      // Fountain (cylinder radius ~2.3)
+      { cx: 0, cz: 0, hw: 2.5, hd: 2.5 },
+      // Mid-distance buildings — bw/2 + 0.3 padding
+      { cx: -13, cz: -10, hw: 2.3, hd: 2.3 },
+      { cx: -13, cz:  10, hw: 1.8, hd: 1.8 },
+      { cx:  13, cz: -10, hw: 1.8, hd: 1.8 },
+      { cx:  13, cz:  10, hw: 2.3, hd: 2.3 },
+      { cx:  -8, cz: -16, hw: 1.8, hd: 1.8 },
+      { cx:   8, cz: -16, hw: 2.3, hd: 2.3 },
+      { cx:  -8, cz:  16, hw: 2.3, hd: 2.3 },
+      { cx:   8, cz:  16, hw: 1.8, hd: 1.8 },
+      // Trees
+      { cx:  -7, cz:  -7, hw: 0.5, hd: 0.5 },
+      { cx:   7, cz:  -7, hw: 0.5, hd: 0.5 },
+      { cx:  -7, cz:   7, hw: 0.5, hd: 0.5 },
+      { cx:   7, cz:   7, hw: 0.5, hd: 0.5 },
+      { cx: -12, cz:   0, hw: 0.5, hd: 0.5 },
+      { cx:  12, cz:   0, hw: 0.5, hd: 0.5 },
+      { cx:   0, cz: -12, hw: 0.5, hd: 0.5 },
+      { cx:   0, cz:  12, hw: 0.5, hd: 0.5 },
+    ],
   },
   cafe: {
     id: 'cafe',
@@ -47,6 +72,25 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     ],
     npcCount: 4,
     npcColors: ['#f59e0b', '#dc2626', '#f97316', '#a855f7'],
+    colliders: [
+      // Counter (16 wide, 2 deep, centred at z=-14)
+      { cx: 0, cz: -14, hw: 8.2, hd: 1.2 },
+      // Sofa corner
+      { cx: 12, cz: -8, hw: 2.3, hd: 1.1 },
+      // Tables (cylinder radius 0.65)
+      { cx: -6, cz: -6, hw: 0.8, hd: 0.8 },
+      { cx: -2, cz: -6, hw: 0.8, hd: 0.8 },
+      { cx:  2, cz: -6, hw: 0.8, hd: 0.8 },
+      { cx:  6, cz: -6, hw: 0.8, hd: 0.8 },
+      { cx: -6, cz: -1, hw: 0.8, hd: 0.8 },
+      { cx: -2, cz: -1, hw: 0.8, hd: 0.8 },
+      { cx:  2, cz: -1, hw: 0.8, hd: 0.8 },
+      { cx:  6, cz: -1, hw: 0.8, hd: 0.8 },
+      { cx: -6, cz:  5, hw: 0.8, hd: 0.8 },
+      { cx: -2, cz:  5, hw: 0.8, hd: 0.8 },
+      { cx:  2, cz:  5, hw: 0.8, hd: 0.8 },
+      { cx:  6, cz:  5, hw: 0.8, hd: 0.8 },
+    ],
   },
   beach: {
     id: 'beach',
@@ -60,6 +104,19 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     ],
     npcCount: 4,
     npcColors: ['#f97316', '#06b6d4', '#84cc16', '#f43f5e'],
+    colliders: [
+      // Ocean wall — blocks everything north of z=-6
+      { cx: 0, cz: -18, hw: 20, hd: 12 },
+      // Palm trees (trunk radius ~0.2)
+      { cx: -10, cz:  -2, hw: 0.45, hd: 0.45 },
+      { cx:  10, cz:   2, hw: 0.45, hd: 0.45 },
+      { cx:  -7, cz:   7, hw: 0.45, hd: 0.45 },
+      { cx:   7, cz:  -4, hw: 0.45, hd: 0.45 },
+      { cx: -14, cz:   6, hw: 0.45, hd: 0.45 },
+      { cx:  14, cz:   0, hw: 0.45, hd: 0.45 },
+      { cx:  -4, cz:  10, hw: 0.45, hd: 0.45 },
+      { cx:   4, cz:  12, hw: 0.45, hd: 0.45 },
+    ],
   },
   library: {
     id: 'library',
@@ -73,5 +130,20 @@ export const ROOMS: Record<RoomId, RoomConfig> = {
     ],
     npcCount: 4,
     npcColors: ['#8b5cf6', '#ec4899', '#0ea5e9', '#10b981'],
+    colliders: [
+      // Reading desks (3.0 wide × 1.6 deep)
+      { cx: -4, cz: -3, hw: 1.6, hd: 0.9 },
+      { cx:  4, cz: -3, hw: 1.6, hd: 0.9 },
+      { cx:  0, cz:  4, hw: 1.6, hd: 0.9 },
+      // Spiral staircase (~1.4 radius)
+      { cx: 13, cz: -12, hw: 1.6, hd: 1.6 },
+      // Reading nooks (low table + seat)
+      { cx: -14, cz: 12, hw: 1.4, hd: 0.8 },
+      { cx:  14, cz: 12, hw: 1.4, hd: 0.8 },
+      // Back-wall bookshelf row (blocks z ≤ -16)
+      { cx: 0, cz: -17.5, hw: 16, hd: 0.8 },
+      // Left-wall bookshelf row (blocks x ≤ -16)
+      { cx: -17.5, cz: 0, hw: 0.8, hd: 16 },
+    ],
   },
 }

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
-import type { RoomId } from '@/lib/roomConfig'
+import { ROOMS, type RoomId } from '@/lib/roomConfig'
+import { resolvePosition } from '@/lib/collision'
 
 export interface NPC {
   id: string
@@ -76,10 +77,13 @@ export const useGameStore = create<GameState>((set) => ({
   setNPCs: (npcs) => set({ npcs }),
 
   tickGame: (delta) => set((state) => {
+    const colliders = ROOMS[state.currentRoom].colliders
+
     const dx = state.playerTargetX - state.playerX
     const dz = state.playerTargetZ - state.playerZ
-    const newX = Math.abs(dx) < 0.05 ? state.playerTargetX : state.playerX + dx * Math.min(delta * 3, 1)
-    const newZ = Math.abs(dz) < 0.05 ? state.playerTargetZ : state.playerZ + dz * Math.min(delta * 3, 1)
+    let newX = Math.abs(dx) < 0.05 ? state.playerTargetX : state.playerX + dx * Math.min(delta * 3, 1)
+    let newZ = Math.abs(dz) < 0.05 ? state.playerTargetZ : state.playerZ + dz * Math.min(delta * 3, 1)
+    ;[newX, newZ] = resolvePosition(newX, newZ, colliders)
 
     const playerChatTimer = Math.max(0, state.playerChatTimer - delta)
     const playerEmoteTimer = Math.max(0, state.playerEmoteTimer - delta)
@@ -87,8 +91,9 @@ export const useGameStore = create<GameState>((set) => ({
     const npcs = state.npcs.map((npc) => {
       const ndx = npc.targetX - npc.x
       const ndz = npc.targetZ - npc.z
-      const nx = Math.abs(ndx) < 0.05 ? npc.targetX : npc.x + ndx * Math.min(delta * 2, 1)
-      const nz = Math.abs(ndz) < 0.05 ? npc.targetZ : npc.z + ndz * Math.min(delta * 2, 1)
+      let nx = Math.abs(ndx) < 0.05 ? npc.targetX : npc.x + ndx * Math.min(delta * 2, 1)
+      let nz = Math.abs(ndz) < 0.05 ? npc.targetZ : npc.z + ndz * Math.min(delta * 2, 1)
+      ;[nx, nz] = resolvePosition(nx, nz, colliders)
 
       const phraseTimer = Math.max(0, npc.phraseTimer - delta)
       let wanderTimer = npc.wanderTimer - delta
@@ -97,8 +102,11 @@ export const useGameStore = create<GameState>((set) => ({
       const phrase = phraseTimer > 0 ? npc.phrase : null
 
       if (wanderTimer <= 0) {
-        targetX = (Math.random() - 0.5) * 28
-        targetZ = (Math.random() - 0.5) * 28
+        let wx = (Math.random() - 0.5) * 28
+        let wz = (Math.random() - 0.5) * 28
+        ;[wx, wz] = resolvePosition(wx, wz, colliders)
+        targetX = wx
+        targetZ = wz
         wanderTimer = 4 + Math.random() * 6
       }
 


### PR DESCRIPTION
## Summary
- New `lib/collision.ts` — circle vs AABB resolver (`resolvePosition`)
- Collider lists added to every room in `lib/roomConfig.ts`:
  - **Plaza**: fountain, 8 buildings, 8 trees
  - **Café**: counter, 12 tables, sofa corner
  - **Praia**: ocean wall (blocks water), 8 palm trees
  - **Biblioteca**: 3 reading desks, spiral staircase, 2 reading nooks, bookshelf walls
- `tickGame` resolves player + NPC positions every frame
- NPC wander targets are also resolved so NPCs never path into walls
- Click-to-walk and WASD both resolve before setting target

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)