### PR TITLE
fix: multiplayer sync — cosmetics, WS_PORT, onclose, and room tracking

### DIFF
--- a/components/game/RemotePlayers.tsx
+++ b/components/game/RemotePlayers.tsx
@@ -2,6 +2,7 @@
 
 import { useGameStore } from '@/store/gameStore'
 import ClaudeOrb from './ClaudeOrb'
+import type { HatId, VehicleId } from '@/lib/skins'
 
 export default function RemotePlayers() {
   const remotePlayers = useGameStore((s) => s.remotePlayers)
@@ -20,6 +21,8 @@ export default function RemotePlayers() {
             name={p.name}
             chat={p.chat}
             emote={p.emote}
+            hat={p.hat as HatId}
+            vehicle={p.vehicle as VehicleId}
           />
         ))}
     </>

--- a/hooks/useMultiplayer.ts
+++ b/hooks/useMultiplayer.ts
@@ -24,10 +24,12 @@ export function useMultiplayer() {
         // Server assigned us an ID — now introduce ourselves
         case 'welcome': {
           ws.send(JSON.stringify({
-            type:  'join',
-            name:  store.playerName  || 'Anon',
-            color: store.playerColor,
-            room:  store.currentRoom,
+            type:    'join',
+            name:    store.playerName  || 'Anon',
+            color:   store.playerColor,
+            hat:     store.playerHat,
+            vehicle: store.playerVehicle,
+            room:    store.currentRoom,
           }))
           break
         }
@@ -42,7 +44,7 @@ export function useMultiplayer() {
           break
 
         case 'player_moved':
-          store.upsertRemotePlayer({ id: String(msg.id), x: Number(msg.x), z: Number(msg.z) })
+          store.upsertRemotePlayer({ id: String(msg.id), x: Number(msg.x), z: Number(msg.z), room: msg.room as RemotePlayer['room'] })
           break
 
         case 'player_chat':
@@ -60,6 +62,7 @@ export function useMultiplayer() {
     }
 
     ws.onerror = () => console.warn('[WS] connection error — is the server running?')
+    ws.onclose = () => useGameStore.getState().setRemotePlayers([])
 
     // ── Throttled position broadcast (~20 Hz) ───────────────────────────
     let lastX = 0, lastZ = 0

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -6,6 +6,8 @@ interface PlayerState {
   id: string
   name: string
   color: string
+  hat: string
+  vehicle: string
   x: number
   z: number
   room: RoomId
@@ -13,7 +15,8 @@ interface PlayerState {
   emote: string | null
 }
 
-const wss = new WebSocketServer({ port: 3001 })
+const PORT = Number(process.env.WS_PORT ?? 3001)
+const wss = new WebSocketServer({ port: PORT })
 const players = new Map<WebSocket, PlayerState>()
 let nextId = 1
 
@@ -42,8 +45,10 @@ wss.on('connection', (ws) => {
     if (msg.type === 'join') {
       const state: PlayerState = {
         id,
-        name:  String(msg.name  || 'Anon').slice(0, 24),
-        color: String(msg.color || '#ea580c'),
+        name:    String(msg.name    || 'Anon').slice(0, 24),
+        color:   String(msg.color   || '#ea580c'),
+        hat:     String(msg.hat     || 'none'),
+        vehicle: String(msg.vehicle || 'none'),
         x: 0, z: 0,
         room:  (msg.room as RoomId) || 'plaza',
         chat:  null,
@@ -68,7 +73,7 @@ wss.on('connection', (ws) => {
       case 'move':
         player.x = Number(msg.x) || 0
         player.z = Number(msg.z) || 0
-        broadcastToRoom(player.room, { type: 'player_moved', id, x: player.x, z: player.z }, ws)
+        broadcastToRoom(player.room, { type: 'player_moved', id, x: player.x, z: player.z, room: player.room }, ws)
         break
 
       // ── chat ────────────────────────────────────────────────────────────
@@ -118,5 +123,4 @@ wss.on('connection', (ws) => {
   })
 })
 
-const PORT = Number(process.env.WS_PORT ?? 3001)
 console.log(`🌐  WS server  →  ws://localhost:${PORT}`)

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -24,6 +24,8 @@ export interface RemotePlayer {
   id: string
   name: string
   color: string
+  hat: string
+  vehicle: string
   x: number
   z: number
   room: RoomId
@@ -133,8 +135,8 @@ export const useGameStore = create<GameState>((set, get) => ({
 
   upsertRemotePlayer: (partial) => set((state) => {
     const existing = state.remotePlayers[partial.id] ?? {
-      id: partial.id, name: '?', color: '#888', x: 0, z: 0,
-      room: state.currentRoom, chat: null, chatTimer: 0, emote: null, emoteTimer: 0,
+      id: partial.id, name: '?', color: '#888', hat: 'none', vehicle: 'none',
+      x: 0, z: 0, room: state.currentRoom, chat: null, chatTimer: 0, emote: null, emoteTimer: 0,
     } as RemotePlayer
     const updated: RemotePlayer = {
       ...existing,


### PR DESCRIPTION
## Summary

Fixes 4 bugs that together made multiplayer unreliable or broken.

- **Cosmetics never visible on remote players** — hat/vehicle were missing from every layer of the data pipeline (server state, join message, RemotePlayer type, and ClaudeOrb render). Fixes #33
- **WS_PORT env var had no effect** — server always bound to hardcoded `3001`; the env var was only read for the console log. Fixes #34
- **Ghost players after disconnect** — no `ws.onclose` handler meant remote players remained in the store when the server went down. Fixes #35
- **`player_moved` upsert used wrong room** — when creating a placeholder for an unknown remote player, it used the local player's `currentRoom` instead of the sender's room. Fixes #36

## Changes

| File | What changed |
|------|-------------|
| `server/ws.ts` | Read `WS_PORT` before `new WebSocketServer`; add `hat`/`vehicle` to `PlayerState`; include `room` in `player_moved` broadcast |
| `store/gameStore.ts` | Add `hat`/`vehicle` to `RemotePlayer` interface; fix upsert fallback |
| `hooks/useMultiplayer.ts` | Include `hat`/`vehicle` in `join` message; pass `room` from `player_moved`; add `ws.onclose` → `setRemotePlayers([])` |
| `components/game/RemotePlayers.tsx` | Pass `hat`/`vehicle` as props to `<ClaudeOrb>` |

## Test plan

- [ ] Start `npm run dev` + `npm run dev:ws` in separate terminals
- [ ] Open two browser windows, enter the game with different players
- [ ] Equip a hat/vehicle in one window → confirm it appears on the other player
- [ ] Kill the WS server → confirm remote player avatars disappear (online count drops)
- [ ] Set `WS_PORT=4000` and restart server → confirm it listens on 4000
- [ ] Change rooms via door/map → confirm players appear/disappear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)