### PR TITLE
fix: color/equip sync, heartbeat, input validation, chatTimer, dev:all

### DIFF
--- a/hooks/useMultiplayer.ts
+++ b/hooks/useMultiplayer.ts
@@ -55,6 +55,14 @@ export function useMultiplayer() {
           store.upsertRemotePlayer({ id: String(msg.id), emote: String(msg.emote), emoteTimer: 2 })
           break
 
+        case 'player_color_changed':
+          store.upsertRemotePlayer({ id: String(msg.id), color: String(msg.color) })
+          break
+
+        case 'player_equipped':
+          store.upsertRemotePlayer({ id: String(msg.id), hat: String(msg.hat), vehicle: String(msg.vehicle) })
+          break
+
         case 'player_left':
           store.removeRemotePlayer(String(msg.id))
           break
@@ -86,6 +94,12 @@ export function useMultiplayer() {
       }
       if (state.playerEmote && state.playerEmote !== prev.playerEmote) {
         ws.send(JSON.stringify({ type: 'emote', emote: state.playerEmote }))
+      }
+      if (state.playerColor !== prev.playerColor) {
+        ws.send(JSON.stringify({ type: 'color_change', color: state.playerColor }))
+      }
+      if (state.playerHat !== prev.playerHat || state.playerVehicle !== prev.playerVehicle) {
+        ws.send(JSON.stringify({ type: 'equip', hat: state.playerHat, vehicle: state.playerVehicle }))
       }
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^19",
         "@types/three": "^0.183.1",
         "@types/ws": "^8.18.1",
+        "concurrently": "9.2.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "tailwindcss": "^4",
@@ -2870,6 +2871,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3363,6 +3374,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3389,6 +3415,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4536,6 +4603,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5052,6 +5129,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -6500,6 +6587,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6583,6 +6680,16 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6784,6 +6891,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -6916,6 +7036,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -7027,6 +7169,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -7230,6 +7385,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/troika-three-text": {
@@ -7739,6 +7904,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -7760,12 +7943,51 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:ws": "tsx server/ws.ts",
+    "dev:all": "concurrently -n next,ws -c cyan,magenta \"npm run dev\" \"npm run dev:ws\"",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19",
     "@types/three": "^0.183.1",
     "@types/ws": "^8.18.1",
+    "concurrently": "9.2.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -15,6 +15,13 @@ interface PlayerState {
   emote: string | null
 }
 
+// Valid IDs kept in sync with lib/skins.ts
+const VALID_HATS     = new Set(['none', 'tophat', 'crown', 'cap', 'cowboy', 'wizard'])
+const VALID_VEHICLES = new Set(['none', 'skateboard'])
+
+function validHat(v: unknown)     { return VALID_HATS.has(String(v))     ? String(v) : 'none' }
+function validVehicle(v: unknown) { return VALID_VEHICLES.has(String(v)) ? String(v) : 'none' }
+
 const PORT = Number(process.env.WS_PORT ?? 3001)
 const wss = new WebSocketServer({ port: PORT })
 const players = new Map<WebSocket, PlayerState>()
@@ -30,7 +37,28 @@ function broadcastToRoom(room: RoomId, data: object, exclude?: WebSocket) {
   }
 }
 
+// ── Heartbeat: detect and terminate dead connections ─────────────────────────
+const HEARTBEAT_MS = 30_000
+type AliveSocket = WebSocket & { isAlive: boolean }
+
+const heartbeatTimer = setInterval(() => {
+  for (const ws of wss.clients) {
+    const socket = ws as AliveSocket
+    if (!socket.isAlive) { socket.terminate(); continue }
+    socket.isAlive = false
+    socket.ping()
+  }
+}, HEARTBEAT_MS)
+
+wss.on('close', () => clearInterval(heartbeatTimer))
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 wss.on('connection', (ws) => {
+  const socket = ws as AliveSocket
+  socket.isAlive = true
+  socket.on('pong', () => { socket.isAlive = true })
+
   const id = `p${nextId++}`
   console.log(`[+] ${id} connected  (total: ${wss.clients.size})`)
   send(ws, { type: 'welcome', id })
@@ -45,10 +73,10 @@ wss.on('connection', (ws) => {
     if (msg.type === 'join') {
       const state: PlayerState = {
         id,
-        name:    String(msg.name    || 'Anon').slice(0, 24),
-        color:   String(msg.color   || '#ea580c'),
-        hat:     String(msg.hat     || 'none'),
-        vehicle: String(msg.vehicle || 'none'),
+        name:    String(msg.name  || 'Anon').slice(0, 24),
+        color:   String(msg.color || '#ea580c'),
+        hat:     validHat(msg.hat),
+        vehicle: validVehicle(msg.vehicle),
         x: 0, z: 0,
         room:  (msg.room as RoomId) || 'plaza',
         chat:  null,
@@ -56,11 +84,8 @@ wss.on('connection', (ws) => {
       }
       players.set(ws, state)
 
-      // Send snapshot of the room the new player is entering
       const roomSnapshot = [...players.values()].filter(p => p.id !== id && p.room === state.room)
       send(ws, { type: 'room_state', players: roomSnapshot })
-
-      // Tell everyone else in the room
       broadcastToRoom(state.room, { type: 'player_joined', player: state }, ws)
       console.log(`[join] ${id} "${state.name}" → ${state.room}`)
       return
@@ -89,6 +114,22 @@ wss.on('connection', (ws) => {
         const emote = String(msg.emote || '')
         player.emote = emote
         broadcastToRoom(player.room, { type: 'player_emote', id, emote }, ws)
+        break
+      }
+
+      // ── color_change ─────────────────────────────────────────────────────
+      case 'color_change': {
+        const color = String(msg.color || '#ea580c')
+        player.color = color
+        broadcastToRoom(player.room, { type: 'player_color_changed', id, color }, ws)
+        break
+      }
+
+      // ── equip ────────────────────────────────────────────────────────────
+      case 'equip': {
+        player.hat     = validHat(msg.hat)
+        player.vehicle = validVehicle(msg.vehicle)
+        broadcastToRoom(player.room, { type: 'player_equipped', id, hat: player.hat, vehicle: player.vehicle }, ws)
         break
       }
 

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -129,7 +129,11 @@ export const useGameStore = create<GameState>((set, get) => ({
   // Multiplayer
   setRemotePlayers: (players) => set({
     remotePlayers: Object.fromEntries(
-      players.map((p) => [p.id, { ...p, chatTimer: 0, emoteTimer: 0 }])
+      players.map((p) => [p.id, {
+        ...p,
+        chatTimer:  p.chat  ? 2 : 0,
+        emoteTimer: p.emote ? 1 : 0,
+      }])
     ),
   }),
 


### PR DESCRIPTION
## Summary

Resolves issues #38–#43. Builds on #37 (already merged).

- **Color change not broadcast** — `color_change` → `player_color_changed`; client subscribes to `playerColor`. Fixes #38
- **Equip not broadcast mid-game** — `equip` → `player_equipped`; client subscribes to `playerHat`/`playerVehicle`. Fixes #39
- **Stale chat bubble on room join** — `setRemotePlayers` seeds `chatTimer: 2` / `emoteTimer: 1` when snapshot has active chat/emote. Fixes #40
- **No `dev:all` script** — `concurrently` script runs Next.js + WS server together. Fixes #41
- **No heartbeat** — 30s ping/pong terminates dead sockets, `close` cleans up. Fixes #42
- **No hat/vehicle validation** — `VALID_HATS`/`VALID_VEHICLES` Sets reject unknown IDs. Fixes #43

## Changes

| File | What changed |
|------|-------------|
| `server/ws.ts` | `color_change`, `equip` handlers; `VALID_HATS`/`VALID_VEHICLES`; heartbeat |
| `hooks/useMultiplayer.ts` | Subscribe to color/hat/vehicle; handle `player_color_changed`, `player_equipped` |
| `store/gameStore.ts` | `setRemotePlayers` seeds timers from non-null chat/emote |
| `package.json` | `dev:all` script with `concurrently` |

## Test plan

- [ ] Change orb color → other players see update in real time
- [ ] Buy/equip hat or vehicle → other players see it immediately
- [ ] Join room where someone was chatting → bubble briefly shows
- [ ] `npm run dev:all` starts both servers in one terminal
- [ ] Kill tab abruptly → ghost player disappears within ~30s
- [ ] Send `hat: "../../etc"` → server normalizes to `none`

🤖 Generated with [Claude Code](https://claude.com/claude-code)