### PR TITLE
fix: wardrobe modal buttons unclickable (missing pointer-events-auto)

### DIFF
--- a/components/ui/WardrobeModal.tsx
+++ b/components/ui/WardrobeModal.tsx
@@ -42,7 +42,7 @@ export default function WardrobeModal({ onClose }: WardrobeModalProps) {
 
   return (
     <div
-      className="absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50"
+      className="pointer-events-auto absolute inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50"
       onClick={onClose}
     >
       <div


### PR DESCRIPTION
## Problem

The wardrobe shop was completely unclickable — buy/equip buttons, tabs, and the close backdrop all did nothing.

## Root Cause

`WardrobeModal` is rendered inside the HUD's root `pointer-events-none` container:

```tsx
// HUD.tsx
<div className="absolute inset-0 pointer-events-none ...">
  ...
  {showWardrobe && <WardrobeModal />}  {/* ← inherits pointer-events: none */}
```

`pointer-events: none` is inherited in CSS. Since `WardrobeModal`'s outer div didn't override it with `pointer-events-auto`, every click was swallowed by the 3D canvas beneath.

The map overlay in the same HUD correctly has `pointer-events-auto` on its div — the wardrobe was just missing it.

## Fix

One character class added to `WardrobeModal`'s backdrop div:

```diff
- className="absolute inset-0 flex items-center justify-center bg-black/60 ..."
+ className="pointer-events-auto absolute inset-0 flex items-center justify-center bg-black/60 ..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)