### PR TITLE
feat: mobile support, procedural sounds, expanded emotes, online token reward

### DIFF
--- a/components/game/GameCanvas.tsx
+++ b/components/game/GameCanvas.tsx
@@ -10,6 +10,7 @@ import Room from './Room'
 import HUD from './HUD'
 import { useGameStore } from '@/store/gameStore'
 import { useMultiplayer } from '@/hooks/useMultiplayer'
+import { useTokenRewards } from '@/hooks/useTokenRewards'
 
 function CameraRig() {
   const controlsRef = useRef<OrbitControlsImpl>(null)
@@ -46,9 +47,10 @@ function CameraRig() {
 
 export default function GameCanvas() {
   useMultiplayer()
+  useTokenRewards()
 
   return (
-    <div className="w-screen h-screen relative">
+    <div className="w-screen h-screen relative" style={{ touchAction: 'none' }}>
       <Canvas
         className="absolute inset-0"
         gl={{ antialias: true }}

--- a/components/game/GroundPlane.tsx
+++ b/components/game/GroundPlane.tsx
@@ -5,6 +5,7 @@ import * as THREE from 'three'
 import { useGameStore } from '@/store/gameStore'
 import { ROOMS } from '@/lib/roomConfig'
 import { resolvePosition } from '@/lib/collision'
+import { playMove } from '@/lib/sounds'
 
 // Invisible horizontal plane — click to walk in XZ
 export default function GroundPlane() {
@@ -18,6 +19,7 @@ export default function GroundPlane() {
     const { currentRoom } = useGameStore.getState()
     ;[x, z] = resolvePosition(x, z, ROOMS[currentRoom].colliders)
     setPlayerTarget(x, z)
+    playMove()
   }
 
   return (

--- a/components/game/HUD.tsx
+++ b/components/game/HUD.tsx
@@ -5,68 +5,129 @@ import { useGameStore } from '@/store/gameStore'
 import { ROOMS } from '@/lib/roomConfig'
 import { ORB_COLORS } from '@/lib/orbColors'
 import WardrobeModal from '@/components/ui/WardrobeModal'
+import { playChat, playEmote, playRoomChange, toggleMute, isMuted } from '@/lib/sounds'
 
-const EMOTES = ['❤️', '✨', '😂', '🤔', '👋', '🎉']
+const EMOTES = [
+  '❤️', '✨', '😂', '🤔', '👋', '🎉',
+  '💃', '😴', '🤖', '🧠', '🔥', '😎',
+]
 
 export default function HUD() {
-  const [chatInput, setChatInput] = useState('')
-  const [showEmotes, setShowEmotes] = useState(false)
-  const [showColors, setShowColors] = useState(false)
-  const [showMap, setShowMap] = useState(false)
+  const [chatInput, setChatInput]     = useState('')
+  const [showEmotes, setShowEmotes]   = useState(false)
+  const [showColors, setShowColors]   = useState(false)
+  const [showMap, setShowMap]         = useState(false)
   const [showWardrobe, setShowWardrobe] = useState(false)
-  const [showDailyToast, setShowDailyToast] = useState(false)
+  const [showDailyToast, setShowDailyToast]   = useState(false)
+  const [showOnlineToast, setShowOnlineToast] = useState(false)
+  const [muted, setMuted]             = useState(false)
 
-  const sendChat = useGameStore((s) => s.sendChat)
-  const sendEmote = useGameStore((s) => s.sendEmote)
+  const sendChat    = useGameStore((s) => s.sendChat)
+  const sendEmote   = useGameStore((s) => s.sendEmote)
   const playerColor = useGameStore((s) => s.playerColor)
   const setPlayerColor = useGameStore((s) => s.setPlayerColor)
-  const currentRoom = useGameStore((s) => s.currentRoom)
-  const changeRoom = useGameStore((s) => s.changeRoom)
+  const currentRoom    = useGameStore((s) => s.currentRoom)
+  const changeRoom     = useGameStore((s) => s.changeRoom)
   const playerName          = useGameStore((s) => s.playerName)
   const tokens              = useGameStore((s) => s.tokens)
   const dailyBonusPending   = useGameStore((s) => s.dailyBonusPending)
   const dismissDailyBonus   = useGameStore((s) => s.dismissDailyBonus)
+  const onlineRewardPending = useGameStore((s) => s.onlineRewardPending)
+  const dismissOnlineReward = useGameStore((s) => s.dismissOnlineReward)
   const remotePlayers       = useGameStore((s) => s.remotePlayers)
   const onlineCount         = Object.keys(remotePlayers).length + 1
 
+  // Daily bonus toast
   useEffect(() => {
     if (dailyBonusPending > 0) {
       setShowDailyToast(true)
-      const t = setTimeout(() => {
-        setShowDailyToast(false)
-        dismissDailyBonus()
-      }, 4000)
+      const t = setTimeout(() => { setShowDailyToast(false); dismissDailyBonus() }, 4000)
       return () => clearTimeout(t)
     }
   }, [dailyBonusPending, dismissDailyBonus])
 
+  // Online time reward toast
+  useEffect(() => {
+    if (onlineRewardPending > 0) {
+      setShowOnlineToast(true)
+      const t = setTimeout(() => { setShowOnlineToast(false); dismissOnlineReward() }, 3000)
+      return () => clearTimeout(t)
+    }
+  }, [onlineRewardPending, dismissOnlineReward])
+
+  // Keyboard shortcuts: 1–9 for emotes
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      const idx = parseInt(e.key) - 1
+      if (idx >= 0 && idx < EMOTES.length) {
+        sendEmote(EMOTES[idx])
+        playEmote()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [sendEmote])
+
   function handleSendChat() {
     if (!chatInput.trim()) return
     sendChat(chatInput.trim())
+    playChat()
     setChatInput('')
     setShowEmotes(false)
+  }
+
+  function handleEmote(emote: string) {
+    sendEmote(emote)
+    playEmote()
+    setShowEmotes(false)
+  }
+
+  function handleChangeRoom(roomId: Parameters<typeof changeRoom>[0]) {
+    changeRoom(roomId)
+    playRoomChange()
+    setShowMap(false)
+  }
+
+  function handleMute() {
+    const m = toggleMute()
+    setMuted(m)
   }
 
   return (
     <div className="absolute inset-0 pointer-events-none flex flex-col justify-between">
       {/* Top bar */}
-      <div className="pointer-events-none flex justify-between items-start pt-4 px-4">
-        <div className="bg-[#111e38cc] border border-[#2a4a7f] rounded-full px-5 py-1.5 font-mono text-sm text-[#7a9cc8] backdrop-blur-sm">
-          {ROOMS[currentRoom].emoji} {ROOMS[currentRoom].name}
-          <span className="ml-3 text-[#3d6db5]">·</span>
-          <span className="ml-3 text-[#5a7aa8] text-xs">{playerName}</span>
-          <span className="ml-3 text-[#3d6db5]">·</span>
-          <span className="ml-2 text-[#5a9a58] text-xs">🟢 {onlineCount}</span>
+      <div className="pointer-events-none flex justify-between items-start pt-4 px-4 gap-2">
+        <div className="bg-[#111e38cc] border border-[#2a4a7f] rounded-full px-4 py-1.5 font-mono text-sm text-[#7a9cc8] backdrop-blur-sm min-w-0 flex items-center gap-2 flex-wrap">
+          <span>{ROOMS[currentRoom].emoji} {ROOMS[currentRoom].name}</span>
+          <span className="text-[#3d6db5]">·</span>
+          <span className="text-[#5a7aa8] text-xs truncate max-w-[100px]">{playerName}</span>
+          <span className="text-[#3d6db5]">·</span>
+          <span className="text-[#5a9a58] text-xs">🟢 {onlineCount}</span>
         </div>
-        <div className="bg-[#111e38cc] border border-[#2a4a7f] rounded-full px-4 py-1.5 font-mono text-sm text-yellow-400 backdrop-blur-sm">
-          💰 {tokens}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="bg-[#111e38cc] border border-[#2a4a7f] rounded-full px-3 py-1.5 font-mono text-sm text-yellow-400 backdrop-blur-sm">
+            💰 {tokens}
+          </div>
+          <button
+            onClick={() => { handleMute() }}
+            className="pointer-events-auto bg-[#111e38cc] border border-[#2a4a7f] rounded-full w-9 h-9 flex items-center justify-center text-base backdrop-blur-sm hover:bg-[#1a2f50cc] transition-colors"
+            title={muted ? 'Unmute' : 'Mute'}
+          >
+            {muted ? '🔇' : '🔊'}
+          </button>
         </div>
       </div>
 
-      {/* Daily login bonus toast */}
+      {/* Toasts */}
       {showDailyToast && (
-        <div className="pointer-events-none absolute top-16 left-1/2 -translate-x-1/2 bg-yellow-500/90 text-black font-mono text-sm font-bold px-5 py-2 rounded-full shadow-lg animate-bounce z-50">
-          🎁 +{dailyBonusPending} tokens — daily login!
+        <div className="pointer-events-none absolute top-16 left-1/2 -translate-x-1/2 bg-yellow-500/90 text-black font-mono text-sm font-bold px-5 py-2 rounded-full shadow-lg animate-bounce z-50 whitespace-nowrap">
+          🎁 +{dailyBonusPending} tokens — login diário!
+        </div>
+      )}
+      {showOnlineToast && (
+        <div className="pointer-events-none absolute top-16 left-1/2 -translate-x-1/2 bg-green-500/90 text-black font-mono text-sm font-bold px-5 py-2 rounded-full shadow-lg animate-bounce z-50 whitespace-nowrap">
+          ⏱️ +{onlineRewardPending} tokens — online reward!
         </div>
       )}
 
@@ -77,7 +138,7 @@ export default function HUD() {
           onClick={() => setShowMap(false)}
         >
           <div
-            className="bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-6 min-w-64"
+            className="bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-6 w-64"
             onClick={(e) => e.stopPropagation()}
           >
             <h2 className="font-mono font-bold text-center mb-4 text-[#7a9cc8]">🗺️ Mapa</h2>
@@ -85,7 +146,7 @@ export default function HUD() {
               {Object.values(ROOMS).map((room) => (
                 <button
                   key={room.id}
-                  onClick={() => { changeRoom(room.id); setShowMap(false) }}
+                  onClick={() => handleChangeRoom(room.id)}
                   className={`flex items-center gap-3 px-4 py-2 rounded-lg font-mono text-sm transition-all ${
                     currentRoom === room.id
                       ? 'bg-[#1e3a8a] border border-[#3d6db5] text-white'
@@ -105,17 +166,21 @@ export default function HUD() {
       {showWardrobe && <WardrobeModal onClose={() => setShowWardrobe(false)} />}
 
       {/* Bottom HUD */}
-      <div className="pointer-events-auto p-3 flex items-end gap-2">
-        {/* Emotes popup */}
+      <div className="pointer-events-auto p-2 sm:p-3 flex items-end gap-1.5 sm:gap-2 overflow-x-auto">
+        {/* Emotes popup — 4×3 grid */}
         {showEmotes && (
-          <div className="absolute bottom-16 left-3 bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-3 flex gap-2 flex-wrap w-48">
-            {EMOTES.map((emote) => (
+          <div className="absolute bottom-16 sm:bottom-[4.5rem] left-2 bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-3 grid grid-cols-4 gap-2 w-52">
+            {EMOTES.map((emote, i) => (
               <button
                 key={emote}
-                onClick={() => { sendEmote(emote); setShowEmotes(false) }}
-                className="text-2xl hover:scale-125 transition-transform"
+                onClick={() => handleEmote(emote)}
+                className="text-2xl hover:scale-125 transition-transform relative"
+                title={`${emote} [${i + 1}]`}
               >
                 {emote}
+                {i < 9 && (
+                  <span className="absolute -top-1 -right-1 text-[8px] text-[#3d6db5] font-mono">{i + 1}</span>
+                )}
               </button>
             ))}
           </div>
@@ -123,7 +188,7 @@ export default function HUD() {
 
         {/* Color picker popup */}
         {showColors && (
-          <div className="absolute bottom-16 left-12 bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-3 grid grid-cols-4 gap-2">
+          <div className="absolute bottom-16 sm:bottom-[4.5rem] left-12 bg-[#111e38] border-2 border-[#2a4a7f] rounded-xl p-3 grid grid-cols-4 gap-2">
             {ORB_COLORS.map((c) => (
               <button
                 key={c.value}
@@ -142,7 +207,7 @@ export default function HUD() {
         {/* Emote button */}
         <button
           onClick={() => { setShowEmotes(!showEmotes); setShowColors(false) }}
-          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0"
+          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
         >
           😊
         </button>
@@ -150,18 +215,18 @@ export default function HUD() {
         {/* Chat input */}
         <form
           onSubmit={(e) => { e.preventDefault(); handleSendChat() }}
-          className="flex-1 flex gap-2"
+          className="flex-1 flex gap-1.5 sm:gap-2 min-w-0"
         >
           <input
             value={chatInput}
             onChange={(e) => setChatInput(e.target.value)}
             placeholder="💬 Digite algo..."
             maxLength={80}
-            className="flex-1 bg-[#0d1b2a] border-2 border-[#2a4a7f] rounded-xl px-4 py-3 text-sm font-mono text-white placeholder-[#3d6db5] outline-none focus:border-[#3d6db5] transition-colors"
+            className="flex-1 min-w-0 bg-[#0d1b2a] border-2 border-[#2a4a7f] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 text-sm font-mono text-white placeholder-[#3d6db5] outline-none focus:border-[#3d6db5] transition-colors"
           />
           <button
             type="submit"
-            className="bg-[#1e3a8a] hover:bg-[#2a4a9a] border-2 border-[#3d6db5] rounded-xl px-4 py-3 text-sm font-mono font-bold transition-colors"
+            className="bg-[#1e3a8a] hover:bg-[#2a4a9a] border-2 border-[#3d6db5] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 text-sm font-mono font-bold transition-colors flex-shrink-0 min-w-[44px] min-h-[44px]"
           >
             ↵
           </button>
@@ -170,7 +235,7 @@ export default function HUD() {
         {/* Orb color button */}
         <button
           onClick={() => { setShowColors(!showColors); setShowEmotes(false) }}
-          className="w-12 h-12 rounded-full border-2 border-white/30 flex-shrink-0 transition-all hover:border-white/70"
+          className="w-11 h-11 rounded-full border-2 border-white/30 flex-shrink-0 transition-all hover:border-white/70"
           style={{
             backgroundColor: playerColor,
             boxShadow: `0 0 12px ${playerColor}88`,
@@ -180,7 +245,7 @@ export default function HUD() {
         {/* Wardrobe button */}
         <button
           onClick={() => { setShowWardrobe(true); setShowEmotes(false); setShowColors(false) }}
-          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0"
+          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
         >
           👕
         </button>
@@ -188,7 +253,7 @@ export default function HUD() {
         {/* Map button */}
         <button
           onClick={() => setShowMap(!showMap)}
-          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0"
+          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
         >
           🗺️
         </button>

--- a/hooks/useTokenRewards.ts
+++ b/hooks/useTokenRewards.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useGameStore } from '@/store/gameStore'
+import { saveTokens } from '@/lib/tokenStore'
+import { playTokenReward } from '@/lib/sounds'
+
+const ONLINE_REWARD = 10
+const ONLINE_INTERVAL_MS = 15 * 60 * 1000   // 15 minutes
+
+export function useTokenRewards() {
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const state = useGameStore.getState()
+      const next = state.tokens + ONLINE_REWARD
+      saveTokens(next)
+      useGameStore.setState({ tokens: next, onlineRewardPending: ONLINE_REWARD })
+      playTokenReward()
+    }, ONLINE_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [])
+}

--- a/lib/sounds.ts
+++ b/lib/sounds.ts
@@ -1,0 +1,106 @@
+// Procedural sounds via Web Audio API — no audio files needed
+// All playback is user-triggered, so autoplay policy is never an issue.
+
+let ctx: AudioContext | null = null
+let muted = false
+
+function getCtx(): AudioContext {
+  if (!ctx) ctx = new AudioContext()
+  if (ctx.state === 'suspended') ctx.resume()
+  return ctx
+}
+
+export function toggleMute(): boolean {
+  muted = !muted
+  return muted
+}
+
+export function isMuted(): boolean {
+  return muted
+}
+
+// Short "tick" when clicking to move
+export function playMove() {
+  if (muted) return
+  const c = getCtx()
+  const osc = c.createOscillator()
+  const gain = c.createGain()
+  osc.connect(gain); gain.connect(c.destination)
+  osc.type = 'triangle'
+  osc.frequency.setValueAtTime(300, c.currentTime)
+  gain.gain.setValueAtTime(0.06, c.currentTime)
+  gain.gain.exponentialRampToValueAtTime(0.001, c.currentTime + 0.07)
+  osc.start(); osc.stop(c.currentTime + 0.07)
+}
+
+// Rising tone when sending a chat message
+export function playChat() {
+  if (muted) return
+  const c = getCtx()
+  const osc = c.createOscillator()
+  const gain = c.createGain()
+  osc.connect(gain); gain.connect(c.destination)
+  osc.type = 'sine'
+  osc.frequency.setValueAtTime(660, c.currentTime)
+  osc.frequency.exponentialRampToValueAtTime(1320, c.currentTime + 0.15)
+  gain.gain.setValueAtTime(0.12, c.currentTime)
+  gain.gain.exponentialRampToValueAtTime(0.001, c.currentTime + 0.3)
+  osc.start(); osc.stop(c.currentTime + 0.3)
+}
+
+// Two-note chime when using an emote
+export function playEmote() {
+  if (muted) return
+  const c = getCtx()
+  const notes = [523, 784]  // C5, G5
+  notes.forEach((freq, i) => {
+    const t = c.currentTime + i * 0.12
+    const osc = c.createOscillator()
+    const gain = c.createGain()
+    osc.connect(gain); gain.connect(c.destination)
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(freq, t)
+    gain.gain.setValueAtTime(0.1, t)
+    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.25)
+    osc.start(t); osc.stop(t + 0.25)
+  })
+}
+
+// Filtered noise swoosh when changing rooms
+export function playRoomChange() {
+  if (muted) return
+  const c = getCtx()
+  const bufLen = Math.floor(c.sampleRate * 0.4)
+  const buf = c.createBuffer(1, bufLen, c.sampleRate)
+  const data = buf.getChannelData(0)
+  for (let i = 0; i < bufLen; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / bufLen)
+  const src = c.createBufferSource()
+  src.buffer = buf
+  const filter = c.createBiquadFilter()
+  filter.type = 'bandpass'
+  filter.frequency.setValueAtTime(600, c.currentTime)
+  filter.frequency.exponentialRampToValueAtTime(120, c.currentTime + 0.4)
+  const gain = c.createGain()
+  gain.gain.setValueAtTime(0.25, c.currentTime)
+  gain.gain.exponentialRampToValueAtTime(0.001, c.currentTime + 0.4)
+  src.connect(filter); filter.connect(gain); gain.connect(c.destination)
+  src.start()
+}
+
+// Ascending arpeggio for token reward
+export function playTokenReward() {
+  if (muted) return
+  const c = getCtx()
+  const notes = [523, 659, 784, 1047]  // C5 E5 G5 C6
+  notes.forEach((freq, i) => {
+    const t = c.currentTime + i * 0.08
+    const osc = c.createOscillator()
+    const gain = c.createGain()
+    osc.connect(gain); gain.connect(c.destination)
+    osc.type = 'triangle'
+    osc.frequency.setValueAtTime(freq, t)
+    gain.gain.setValueAtTime(0.1, t)
+    gain.gain.exponentialRampToValueAtTime(0.001, t + 0.2)
+    osc.start(t); osc.stop(t + 0.2)
+  })
+}

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -54,6 +54,7 @@ export interface GameState {
   tokens: number
   inventory: string[]
   dailyBonusPending: number
+  onlineRewardPending: number
 
   // World
   currentRoom: RoomId
@@ -83,6 +84,7 @@ export interface GameState {
   buyItem: (itemId: string, cost: number) => boolean
   initPlayer: () => void
   dismissDailyBonus: () => void
+  dismissOnlineReward: () => void
 }
 
 export const useGameStore = create<GameState>((set, get) => ({
@@ -101,6 +103,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   tokens: 0,
   inventory: ['none'],
   dailyBonusPending: 0,
+  onlineRewardPending: 0,
   currentRoom: 'plaza',
   npcs: [],
   remotePlayers: {},
@@ -281,4 +284,5 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
 
   dismissDailyBonus: () => set({ dailyBonusPending: 0 }),
+  dismissOnlineReward: () => set({ onlineRewardPending: 0 }),
 }))


### PR DESCRIPTION
## Summary

Resolves #26, #19, #18, #20 (online time reward).

### Mobile (#26)
- `touch-action: none` on canvas container — prevents browser scroll/zoom hijacking on iOS/Android
- All HUD buttons enforce `min-w/h: 44px` (Apple HIG tap target standard)
- Bottom bar uses `overflow-x-auto` for narrow viewports
- Responsive `sm:` breakpoints for padding and gap

### Sounds (#19)
- `lib/sounds.ts` — Web Audio API procedural tones, **zero audio files, zero dependencies**
- `playMove` on ground tap/click, `playChat` on message send, `playEmote` on emote use, `playRoomChange` on room transition, `playTokenReward` on online reward
- 🔊/🔇 mute toggle button in top-right corner

### Emotes (#18)
- Expanded from 6 → 12 emotes (💃 😴 🤖 🧠 🔥 😎 added)
- 4×3 grid popup
- Keyboard shortcuts **1–9** displayed as badge on each emote
- Shortcuts fire when not focused on text input

### Online token reward (#20)
- `useTokenRewards` hook — +10 tokens every 15 min while online
- Persisted to localStorage, green toast notification, ascending arpeggio sound
- `onlineRewardPending` / `dismissOnlineReward` added to store

## Test plan

- [ ] Tap ground on mobile → player walks, tick sound plays
- [ ] Send chat → rising tone
- [ ] Use emote via button and via keyboard shortcut (1-9)
- [ ] Change room → swoosh sound
- [ ] Mute button silences all sounds
- [ ] HUD buttons usable on 375px viewport without horizontal scroll
- [ ] Online reward toast appears after 15min (or reduce interval in dev to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)