### PR TITLE
fix: bugs, perf, a11y, and UX improvements

### DIFF
--- a/components/game/BeachMinigame.tsx
+++ b/components/game/BeachMinigame.tsx
@@ -36,7 +36,6 @@ export default function BeachMinigame({ onClose }: Props) {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const storeTokens  = useGameStore((s) => s.tokens)
-  const setStoreTokens = useGameStore((s) => s.tokens) // read-only; we'll use set directly
 
   function start() {
     setPhase('playing')

--- a/components/game/ClaudeOrb.tsx
+++ b/components/game/ClaudeOrb.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useMemo } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { Html } from '@react-three/drei'
 import * as THREE from 'three'
@@ -116,7 +116,7 @@ export default function ClaudeOrb({
 
   // Generate static particle positions — orbiting via group rotation
   const particleCount = Math.min(auraConfig.particleCount, 20)
-  const particles = Array.from({ length: particleCount }, (_, i) => {
+  const particles = useMemo(() => Array.from({ length: particleCount }, (_, i) => {
     const angle = (i / particleCount) * Math.PI * 2
     const r = 0.75 + (i % 3) * 0.15
     const py = 0.8 + (i % 5) * 0.22
@@ -126,7 +126,7 @@ export default function ClaudeOrb({
         <meshStandardMaterial color={auraColor} emissive={auraColor} emissiveIntensity={2.2} toneMapped={false} />
       </mesh>
     )
-  })
+  }), [particleCount, auraColor])
 
   return (
     <group position={[x, 0, z]} scale={[scale, scale, scale]}>

--- a/components/game/HUD.tsx
+++ b/components/game/HUD.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useGameStore } from '@/store/gameStore'
 import { ROOMS } from '@/lib/roomConfig'
 import { ORB_COLORS } from '@/lib/orbColors'
@@ -10,6 +10,7 @@ import BeachMinigame from '@/components/game/BeachMinigame'
 import AchievementsModal from '@/components/ui/AchievementsModal'
 import { getLevel } from '@/lib/githubLevel'
 import { ACHIEVEMENTS } from '@/lib/achievements'
+import { playChat, playEmote, playRoomChange, toggleMute, isMuted } from '@/lib/sounds'
 
 const EMOTES = [
   '❤️', '✨', '😂', '🤔', '👋', '🎉',
@@ -31,6 +32,10 @@ export default function HUD() {
   const [githubLoading, setGithubLoading] = useState(false)
   const [githubError, setGithubError] = useState<string | null>(null)
   const [showAchievementToast, setShowAchievementToast] = useState(false)
+  const [showOnlineToast, setShowOnlineToast] = useState(false)
+  const [muted, setMuted] = useState(false)
+  const [chatCooldown, setChatCooldown] = useState(false)
+  const cooldownRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const sendChat    = useGameStore((s) => s.sendChat)
   const sendEmote   = useGameStore((s) => s.sendEmote)
@@ -44,13 +49,13 @@ export default function HUD() {
   const dismissDailyBonus   = useGameStore((s) => s.dismissDailyBonus)
   const onlineRewardPending = useGameStore((s) => s.onlineRewardPending)
   const dismissOnlineReward = useGameStore((s) => s.dismissOnlineReward)
-  const remotePlayers       = useGameStore((s) => s.remotePlayers)
+  const onlineCount         = useGameStore((s) => Object.keys(s.remotePlayers).length) + 1
+  const wsConnected         = useGameStore((s) => s.wsConnected)
   const githubLevel         = useGameStore((s) => s.githubLevel)
   const githubUsername      = useGameStore((s) => s.githubUsername)
   const setGithubLevel      = useGameStore((s) => s.setGithubLevel)
   const pendingAchievement  = useGameStore((s) => s.pendingAchievement)
   const dismissAchievement  = useGameStore((s) => s.dismissAchievement)
-  const onlineCount         = Object.keys(remotePlayers).length + 1
 
   // Daily bonus toast
   useEffect(() => {
@@ -72,6 +77,15 @@ export default function HUD() {
       return () => clearTimeout(t)
     }
   }, [pendingAchievement, dismissAchievement])
+
+  // Online reward toast
+  useEffect(() => {
+    if (onlineRewardPending > 0) {
+      setShowOnlineToast(true)
+      const t = setTimeout(() => { setShowOnlineToast(false); dismissOnlineReward() }, 4000)
+      return () => clearTimeout(t)
+    }
+  }, [onlineRewardPending, dismissOnlineReward])
 
   // Prefill github input when modal opens
   useEffect(() => {
@@ -103,11 +117,13 @@ export default function HUD() {
   const pendingAchievementDef = pendingAchievement ? ACHIEVEMENTS[pendingAchievement] : null
 
   function handleSendChat() {
-    if (!chatInput.trim()) return
+    if (!chatInput.trim() || chatCooldown) return
     sendChat(chatInput.trim())
     playChat()
     setChatInput('')
     setShowEmotes(false)
+    setChatCooldown(true)
+    cooldownRef.current = setTimeout(() => setChatCooldown(false), 500)
   }
 
   function handleEmote(emote: string) {
@@ -122,11 +138,6 @@ export default function HUD() {
     setShowMap(false)
   }
 
-  function handleMute() {
-    const m = toggleMute()
-    setMuted(m)
-  }
-
   return (
     <div className="absolute inset-0 pointer-events-none flex flex-col justify-between">
       {/* Top bar */}
@@ -139,7 +150,9 @@ export default function HUD() {
           <span className="ml-3 text-[#3d6db5]">·</span>
           <span className="ml-3 text-[#5a7aa8] text-xs">{playerName}</span>
           <span className="ml-3 text-[#3d6db5]">·</span>
-          <span className="ml-2 text-[#5a9a58] text-xs">🟢 {onlineCount}</span>
+          <span className={`ml-2 text-xs ${wsConnected ? 'text-[#5a9a58]' : 'text-red-400'}`}>
+            {wsConnected ? `🟢 ${onlineCount}` : '🔴 offline'}
+          </span>
         </button>
         <div className="flex items-center gap-2">
           <button
@@ -306,6 +319,7 @@ export default function HUD() {
         <button
           onClick={() => { setShowEmotes(!showEmotes); setShowColors(false) }}
           className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label="Emotes"
         >
           😊
         </button>
@@ -338,12 +352,14 @@ export default function HUD() {
             backgroundColor: playerColor,
             boxShadow: `0 0 12px ${playerColor}88`,
           }}
+          aria-label="Change color"
         />
 
         {/* Wardrobe button */}
         <button
           onClick={() => { setShowWardrobe(true); setShowEmotes(false); setShowColors(false) }}
           className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label="Wardrobe"
         >
           👕
         </button>
@@ -352,6 +368,7 @@ export default function HUD() {
         <button
           onClick={() => { setShowAchievements(true); setShowEmotes(false); setShowColors(false) }}
           className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0"
+          aria-label="Achievements"
         >
           🏆
         </button>
@@ -360,8 +377,18 @@ export default function HUD() {
         <button
           onClick={() => setShowMap(!showMap)}
           className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label="Map"
         >
           🗺️
+        </button>
+
+        {/* Mute button */}
+        <button
+          onClick={() => { const m = toggleMute(); setMuted(m) }}
+          className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
+          aria-label={muted ? 'Unmute sounds' : 'Mute sounds'}
+        >
+          {muted ? '🔇' : '🔊'}
         </button>
 
         {/* Minigame button — beach only */}
@@ -369,6 +396,7 @@ export default function HUD() {
           <button
             onClick={() => setShowMinigame(true)}
             className="bg-[#1a3a20] border-2 border-[#f0c060] rounded-xl p-3 text-xl hover:bg-[#2a4a30] transition-colors flex-shrink-0 animate-pulse"
+            aria-label="Token Rush minigame"
             title="Token Rush — minijogo"
           >
             🎮

--- a/hooks/useMultiplayer.ts
+++ b/hooks/useMultiplayer.ts
@@ -87,8 +87,12 @@ export function useMultiplayer() {
       }
     }
 
+    ws.onopen = () => useGameStore.setState({ wsConnected: true })
     ws.onerror = () => console.warn('[WS] connection error — is the server running?')
-    ws.onclose = () => useGameStore.getState().setRemotePlayers([])
+    ws.onclose = () => {
+      useGameStore.setState({ wsConnected: false })
+      useGameStore.getState().setRemotePlayers([])
+    }
 
     // ── Throttled position broadcast (~20 Hz) ───────────────────────────
     let lastX = 0, lastZ = 0

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -85,6 +85,7 @@ export interface GameState {
   npcs: NPC[]
 
   // Multiplayer
+  wsConnected: boolean
   remotePlayers: Record<string, RemotePlayer>
 
   // Actions
@@ -109,6 +110,7 @@ export interface GameState {
   buyItem: (itemId: string, cost: number) => boolean
   initPlayer: () => void
   dismissDailyBonus: () => void
+  dismissOnlineReward: () => void
 
   // GitHub level
   setGithubLevel: (username: string, level: number, contributions: number) => void
@@ -136,6 +138,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   tokens: 0,
   inventory: ['none'],
   dailyBonusPending: 0,
+  onlineRewardPending: 0,
   githubUsername: '',
   githubLevel: 1,
   githubContributions: 0,
@@ -153,6 +156,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   pendingAchievement: null,
   currentRoom: 'plaza',
   npcs: [],
+  wsConnected: false,
   remotePlayers: {},
 
   setPlayer: (name, color) => set({ playerName: name, playerColor: color }),
@@ -395,6 +399,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   },
 
   dismissDailyBonus: () => set({ dailyBonusPending: 0 }),
+  dismissOnlineReward: () => set({ onlineRewardPending: 0 }),
 
   // ── GitHub level ────────────────────────────────────────────────────
   setGithubLevel: (username, level, contributions) => {


### PR DESCRIPTION
## Summary
- **Bug fixes**: Online reward toast now displays (#63), dead code removed (#70)
- **Performance**: HUD no longer re-renders on every player move (#64), ClaudeOrb particles memoized (#65)
- **UX**: WebSocket connection status shown in top bar (#66), mute toggle button added (#68), chat cooldown prevents spam (#69)
- **Accessibility**: aria-labels on all icon-only buttons (#67)

Resolves #63, #64, #65, #66, #67, #68, #69, #70

## Test plan
- [ ] Verify online reward toast appears when `onlineRewardPending > 0`
- [ ] Check top bar shows "offline" when WS server is down
- [ ] Confirm mute button toggles sound on/off with icon change
- [ ] Test chat cooldown (rapid messages should be throttled)
- [ ] Verify HUD buttons are announced correctly by screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)