### PR TITLE
fix: sync visited houses over realtime

### DIFF
--- a/components/game/HUD.tsx
+++ b/components/game/HUD.tsx
@@ -62,6 +62,10 @@ export default function HUD() {
   const dismissAchievement  = useGameStore((s) => s.dismissAchievement)
   const houseEditMode       = useGameStore((s) => s.houseEditMode)
   const setHouseEditMode    = useGameStore((s) => s.setHouseEditMode)
+  const houseOwnerId        = useGameStore((s) => s.houseOwnerId)
+  const houseOwnerName      = useGameStore((s) => s.houseOwnerName)
+  const enterOwnHouse       = useGameStore((s) => s.enterOwnHouse)
+  const isVisitingHouse     = currentRoom === 'house' && Boolean(houseOwnerId)
 
   // Cleanup chat cooldown timer on unmount
   useEffect(() => {
@@ -171,7 +175,7 @@ export default function HUD() {
           onClick={() => setShowProfile(true)}
           className="bg-[#111e38cc] border border-[#2a4a7f] rounded-full px-5 py-1.5 font-mono text-sm text-[#7a9cc8] backdrop-blur-sm hover:border-[#3d6db5] transition-colors"
         >
-          {ROOMS[currentRoom].emoji} {ROOMS[currentRoom].name}
+          {ROOMS[currentRoom].emoji} {isVisitingHouse ? `Casa de ${houseOwnerName ?? 'Amigo'}` : ROOMS[currentRoom].name}
           <span className="ml-3 text-[#3d6db5]">·</span>
           <span className="ml-3 text-[#5a7aa8] text-xs">{playerName}</span>
           <span className="ml-3 text-[#3d6db5]">·</span>
@@ -262,6 +266,9 @@ export default function HUD() {
 
       {/* Achievements modal */}
       {showAchievements && <AchievementsModal onClose={() => setShowAchievements(false)} />}
+
+      {/* Friends modal */}
+      {showFriends && <FriendsModal onClose={() => setShowFriends(false)} />}
 
       {/* Furniture shop modal */}
       {showFurnitureShop && <FurnitureShopModal onClose={() => setShowFurnitureShop(false)} />}
@@ -447,7 +454,7 @@ export default function HUD() {
 
         {/* House button — go to my house */}
         <button
-          onClick={() => changeRoom('house')}
+          onClick={enterOwnHouse}
           className="bg-[#1a2744] border-2 border-[#2a4a7f] rounded-xl p-2.5 sm:p-3 text-xl hover:bg-[#243060] transition-colors flex-shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center"
           aria-label="Minha casa"
           title="Minha Casa"
@@ -456,7 +463,7 @@ export default function HUD() {
         </button>
 
         {/* House edit mode — house only */}
-        {currentRoom === 'house' ? (
+        {currentRoom === 'house' && !isVisitingHouse ? (
           <>
             <button
               onClick={() => setHouseEditMode(!houseEditMode)}

--- a/components/rooms/HouseRoom.tsx
+++ b/components/rooms/HouseRoom.tsx
@@ -186,7 +186,7 @@ function FurnitureShape({
 
 // ── Floor click handler in edit mode ─────────────────────────────────────────
 
-function EditFloor({ selectedType, onPlace }: { selectedType: FurnitureId; onPlace: (x: number, z: number) => void }) {
+function EditFloor({ onPlace }: { onPlace: (x: number, z: number) => void }) {
   return (
     <mesh
       rotation={[-Math.PI / 2, 0, 0]}
@@ -208,11 +208,16 @@ function EditFloor({ selectedType, onPlace }: { selectedType: FurnitureId; onPla
 // ── Main HouseRoom ────────────────────────────────────────────────────────────
 
 export default function HouseRoom() {
-  const houseItems     = useGameStore((s) => s.houseItems)
-  const houseEditMode  = useGameStore((s) => s.houseEditMode)
-  const addFurniture   = useGameStore((s) => s.addFurniture)
+  const houseItems      = useGameStore((s) => s.houseItems)
+  const visitedHouseItems = useGameStore((s) => s.visitedHouseItems)
+  const houseEditMode   = useGameStore((s) => s.houseEditMode)
+  const houseOwnerId    = useGameStore((s) => s.houseOwnerId)
+  const houseOwnerName  = useGameStore((s) => s.houseOwnerName)
+  const addFurniture    = useGameStore((s) => s.addFurniture)
   const removeFurniture = useGameStore((s) => s.removeFurniture)
   const rotateFurniture = useGameStore((s) => s.rotateFurniture)
+  const isOwnerHouse = !houseOwnerId
+  const renderedItems = isOwnerHouse ? houseItems : visitedHouseItems
 
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [placingType, setPlacingType] = useState<FurnitureId | null>(null)
@@ -227,7 +232,7 @@ export default function HouseRoom() {
     setPlacingType(null)
   }
 
-  const selectedItem = houseItems.find((i) => i.id === selectedId)
+  const selectedItem = renderedItems.find((i) => i.id === selectedId)
 
   return (
     <>
@@ -282,22 +287,22 @@ export default function HouseRoom() {
       </mesh>
 
       {/* Placed furniture */}
-      {houseItems.map((item) => (
+      {renderedItems.map((item) => (
         <FurnitureMesh
           key={item.id}
           item={item}
-          editMode={houseEditMode}
+          editMode={houseEditMode && isOwnerHouse}
           onSelect={handleSelect}
         />
       ))}
 
       {/* Edit floor overlay for placing */}
-      {houseEditMode && placingType && (
-        <EditFloor selectedType={placingType} onPlace={handlePlace} />
+      {houseEditMode && isOwnerHouse && placingType && (
+        <EditFloor onPlace={handlePlace} />
       )}
 
       {/* Furniture action tooltip */}
-      {houseEditMode && selectedItem && (
+      {houseEditMode && isOwnerHouse && selectedItem && (
         <Html
           position={[selectedItem.x, 2.5, selectedItem.z]}
           center
@@ -330,7 +335,7 @@ export default function HouseRoom() {
       )}
 
       {/* Edit mode: place picker panel */}
-      {houseEditMode && (
+      {houseEditMode && isOwnerHouse && (
         <Html
           position={[0, 0, HALF - 1]}
           center
@@ -362,11 +367,29 @@ export default function HouseRoom() {
         </Html>
       )}
 
+      {!isOwnerHouse && (
+        <Html position={[0, 3.2, 0]} center>
+          <div
+            style={{
+              background: 'rgba(0,0,0,0.75)',
+              border: '1px solid rgba(122,156,200,0.45)',
+              borderRadius: 10,
+              color: '#fff',
+              padding: '8px 12px',
+              fontSize: 12,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Visitando a casa de {houseOwnerName ?? 'Amigo'}
+          </div>
+        </Html>
+      )}
+
       {/* Door */}
       <Door config={room.doors[0]} accentColor={room.accentColor} />
 
       {/* Ground plane for walking */}
-      {!houseEditMode && <GroundPlane />}
+      {(!houseEditMode || !isOwnerHouse) && <GroundPlane />}
     </>
   )
 }

--- a/components/ui/FriendsModal.tsx
+++ b/components/ui/FriendsModal.tsx
@@ -9,7 +9,7 @@ interface Props {
 export default function FriendsModal({ onClose }: Props) {
   const friends = useGameStore((s) => s.friends)
   const remotePlayers = useGameStore((s) => s.remotePlayers)
-  const changeRoom = useGameStore((s) => s.changeRoom)
+  const visitHouse = useGameStore((s) => s.visitHouse)
   const removeFriend = useGameStore((s) => s.removeFriend)
 
   const entries = friends
@@ -17,9 +17,9 @@ export default function FriendsModal({ onClose }: Props) {
     .sort((a, b) => Number(Boolean(b.remote)) - Number(Boolean(a.remote)))
 
   function handleVisit(friendId: string) {
-    const remote = remotePlayers[friendId]
-    if (!remote) return
-    changeRoom(remote.room)
+    const friend = friends.find((entry) => entry.id === friendId)
+    if (!friend || !remotePlayers[friendId]) return
+    visitHouse(friend.id, friend.name)
     onClose()
   }
 

--- a/hooks/useMultiplayer.ts
+++ b/hooks/useMultiplayer.ts
@@ -4,9 +4,12 @@ import { useEffect, useRef } from 'react'
 import * as Ably from 'ably'
 import { useGameStore } from '@/store/gameStore'
 import {
+  buildHousePresenceData,
   buildPresencePlayerData,
   getRealtimeClientId,
+  getRealtimeHouseChannel,
   getRealtimeRoomChannel,
+  presenceDataToHouseState,
   presenceDataToRemotePlayer,
 } from '@/lib/realtime'
 
@@ -16,6 +19,8 @@ const MOVE_THRESHOLD = 0.01 // skip tiny position changes
 export function useMultiplayer() {
   const realtimeRef = useRef<Ably.Realtime | null>(null)
   const channelRef = useRef<Ably.RealtimeChannel | null>(null)
+  const ownHouseChannelRef = useRef<Ably.RealtimeChannel | null>(null)
+  const visitingHouseChannelRef = useRef<Ably.RealtimeChannel | null>(null)
   const roomRef = useRef<string | null>(null)
   const joinTokenRef = useRef(0)
 
@@ -40,6 +45,15 @@ export function useMultiplayer() {
         x: state.playerX,
         z: state.playerZ,
         room: state.currentRoom,
+      })
+    }
+
+    const buildOwnHousePresence = () => {
+      const state = useGameStore.getState()
+      return buildHousePresenceData({
+        ownerId: clientId,
+        ownerName: state.playerName || 'Anon',
+        items: state.houseItems,
       })
     }
 
@@ -101,6 +115,35 @@ export function useMultiplayer() {
       }
     }
 
+    const syncVisitedHouse = async (channel: Ably.RealtimeChannel, ownerId: string) => {
+      const members = await channel.presence.get()
+      const ownerState = members
+        .filter((member) => member.clientId === ownerId)
+        .map((member) => presenceDataToHouseState(member.data ?? {}))
+        .find((value): value is NonNullable<typeof value> => value !== null)
+
+      useGameStore.getState().setVisitedHouse(
+        ownerId,
+        ownerState?.ownerName ?? null,
+        ownerState?.items ?? [],
+      )
+    }
+
+    const handleVisitedHousePresence = (message: Ably.PresenceMessage) => {
+      const store = useGameStore.getState()
+      const ownerId = store.houseOwnerId
+      if (!ownerId || message.clientId !== ownerId) return
+
+      if (message.action === 'leave') {
+        store.setVisitedHouse(ownerId, store.houseOwnerName, [])
+        return
+      }
+
+      const ownerState = presenceDataToHouseState(message.data ?? {})
+      if (!ownerState) return
+      store.setVisitedHouse(ownerState.ownerId, ownerState.ownerName, ownerState.items)
+    }
+
     const leaveCurrentRoom = async () => {
       const current = channelRef.current
       if (!current) return
@@ -114,11 +157,32 @@ export function useMultiplayer() {
       roomRef.current = null
     }
 
+    const leaveVisitedHouse = async () => {
+      const channel = visitingHouseChannelRef.current
+      if (!channel) return
+
+      channel.presence.unsubscribe(handleVisitedHousePresence)
+      try { await channel.detach() } catch {}
+      visitingHouseChannelRef.current = null
+      useGameStore.getState().setVisitedHouse(null, null, [])
+    }
+
+    const joinVisitedHouse = async (ownerId: string) => {
+      await leaveVisitedHouse()
+
+      const channel = realtime.channels.get(getRealtimeHouseChannel(ownerId))
+      visitingHouseChannelRef.current = channel
+      await channel.presence.subscribe(handleVisitedHousePresence)
+      await syncVisitedHouse(channel, ownerId)
+    }
+
     const joinRoom = async (room: ReturnType<typeof useGameStore.getState>['currentRoom']) => {
       const joinToken = ++joinTokenRef.current
       await leaveCurrentRoom()
 
-      const channel = realtime.channels.get(getRealtimeRoomChannel(room))
+      const state = useGameStore.getState()
+      const houseScopeId = room === 'house' ? (state.houseOwnerId || clientId) : null
+      const channel = realtime.channels.get(getRealtimeRoomChannel(room, houseScopeId))
       channelRef.current = channel
       roomRef.current = room
 
@@ -146,6 +210,10 @@ export function useMultiplayer() {
       console.warn('[realtime] connection failed')
       useGameStore.setState({ wsConnected: false, remotePlayers: {} })
     })
+
+    const ownHouseChannel = realtime.channels.get(getRealtimeHouseChannel(clientId))
+    ownHouseChannelRef.current = ownHouseChannel
+    void ownHouseChannel.presence.enter(buildOwnHousePresence())
 
     // ── Throttled position broadcast (~20 Hz) ───────────────────────────
     let lastX = 0
@@ -176,8 +244,21 @@ export function useMultiplayer() {
       if (!channel) return
 
       if (state.currentRoom !== prev.currentRoom) {
+        if (state.currentRoom === 'house' && state.houseOwnerId) {
+          void joinVisitedHouse(state.houseOwnerId)
+        } else {
+          void leaveVisitedHouse()
+        }
         void joinRoom(state.currentRoom)
         return
+      }
+
+      if (state.houseOwnerId !== prev.houseOwnerId) {
+        if (state.currentRoom === 'house' && state.houseOwnerId) {
+          void joinVisitedHouse(state.houseOwnerId)
+        } else {
+          void leaveVisitedHouse()
+        }
       }
 
       if (state.playerChat && state.playerChat !== prev.playerChat) {
@@ -196,12 +277,21 @@ export function useMultiplayer() {
       ) {
         void channel.presence.update(buildSelfPresence())
       }
+
+      if (
+        state.playerName !== prev.playerName ||
+        state.houseItems !== prev.houseItems
+      ) {
+        void ownHouseChannel.presence.update(buildOwnHousePresence())
+      }
     })
 
     return () => {
       window.clearInterval(moveTimer)
       unsub()
       void leaveCurrentRoom()
+      void leaveVisitedHouse()
+      try { void ownHouseChannel.presence.leave() } catch {}
       realtime.close()
     }
   }, [])

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,8 +1,10 @@
 import type { RoomId } from '@/lib/roomConfig'
+import type { PlacedFurniture } from '@/lib/furniture'
 import type { RemotePlayer } from '@/store/gameStore'
 
 const CLIENT_ID_KEY = 'vibeland-realtime-client-id'
 const ROOM_CHANNEL_PREFIX = 'vibeland:room:'
+const HOUSE_CHANNEL_PREFIX = 'vibeland:house:'
 
 type PresencePlayerData = {
   name?: unknown
@@ -14,6 +16,12 @@ type PresencePlayerData = {
   x?: unknown
   z?: unknown
   room?: unknown
+}
+
+type HousePresenceData = {
+  ownerId?: unknown
+  ownerName?: unknown
+  items?: unknown
 }
 
 export function getRealtimeClientId() {
@@ -31,8 +39,16 @@ export function sanitizeClientId(value: string) {
   return value.replace(/[^a-zA-Z0-9:_-]/g, '').slice(0, 80)
 }
 
-export function getRealtimeRoomChannel(room: RoomId) {
+export function getRealtimeRoomChannel(room: RoomId, houseOwnerId?: string | null) {
+  if (room === 'house') {
+    const ownerId = houseOwnerId ? sanitizeClientId(houseOwnerId) : 'self'
+    return `${ROOM_CHANNEL_PREFIX}${room}:${ownerId}`
+  }
   return `${ROOM_CHANNEL_PREFIX}${room}`
+}
+
+export function getRealtimeHouseChannel(ownerId: string) {
+  return `${HOUSE_CHANNEL_PREFIX}${sanitizeClientId(ownerId)}`
 }
 
 export function buildPresencePlayerData(input: {
@@ -82,5 +98,55 @@ export function presenceDataToRemotePlayer(clientId: string, data: PresencePlaye
     chatTimer: 0,
     emote: null,
     emoteTimer: 0,
+  }
+}
+
+export function buildHousePresenceData(input: {
+  ownerId: string
+  ownerName: string
+  items: PlacedFurniture[]
+}) {
+  return {
+    ownerId: sanitizeClientId(input.ownerId),
+    ownerName: input.ownerName.trim().slice(0, 24) || 'Anon',
+    items: input.items,
+  }
+}
+
+export function presenceDataToHouseState(data: HousePresenceData): {
+  ownerId: string
+  ownerName: string
+  items: PlacedFurniture[]
+} | null {
+  if (typeof data.ownerId !== 'string' || !data.ownerId) return null
+
+  const items = Array.isArray(data.items)
+    ? data.items.flatMap((item): PlacedFurniture[] => {
+        if (!item || typeof item !== 'object') return []
+        const candidate = item as Record<string, unknown>
+        if (
+          typeof candidate.id !== 'string' ||
+          typeof candidate.type !== 'string' ||
+          typeof candidate.x !== 'number' ||
+          typeof candidate.z !== 'number' ||
+          typeof candidate.rotation !== 'number'
+        ) return []
+
+        return [{
+          id: candidate.id,
+          type: candidate.type as PlacedFurniture['type'],
+          x: candidate.x,
+          z: candidate.z,
+          rotation: candidate.rotation,
+        }]
+      })
+    : []
+
+  return {
+    ownerId: sanitizeClientId(data.ownerId),
+    ownerName: typeof data.ownerName === 'string' && data.ownerName.trim()
+      ? data.ownerName.trim().slice(0, 24)
+      : 'Anon',
+    items,
   }
 }

--- a/store/gameStore.ts
+++ b/store/gameStore.ts
@@ -74,11 +74,17 @@ export interface GameState {
 
   // House
   houseItems: PlacedFurniture[]
+  visitedHouseItems: PlacedFurniture[]
   houseEditMode: boolean
+  houseOwnerId: string | null
+  houseOwnerName: string | null
   addFurniture: (type: FurnitureId, x: number, z: number) => void
   removeFurniture: (id: string) => void
   rotateFurniture: (id: string) => void
   setHouseEditMode: (enabled: boolean) => void
+  setVisitedHouse: (ownerId: string | null, ownerName: string | null, items: PlacedFurniture[]) => void
+  visitHouse: (ownerId: string, ownerName: string) => void
+  enterOwnHouse: () => void
 
   // World
   currentRoom: RoomId
@@ -140,7 +146,10 @@ export const useGameStore = create<GameState>((set, get) => ({
   dailyBonusPending: 0,
   onlineRewardPending: 0,
   houseItems: [],
+  visitedHouseItems: [],
   houseEditMode: false,
+  houseOwnerId: null,
+  houseOwnerName: null,
   friends: [],
   githubUsername: '',
   githubLevel: 1,
@@ -207,6 +216,9 @@ export const useGameStore = create<GameState>((set, get) => ({
       remotePlayers: {},
       gameStats: newStats,
       houseEditMode: false,
+      houseOwnerId: room === 'house' ? get().houseOwnerId : null,
+      houseOwnerName: room === 'house' ? get().houseOwnerName : null,
+      visitedHouseItems: room === 'house' ? get().visitedHouseItems : [],
     })
     get().checkAchievements()
   },
@@ -362,6 +374,9 @@ export const useGameStore = create<GameState>((set, get) => ({
       githubLevel: githubData?.level ?? 1,
       githubContributions: githubData?.contributions ?? 0,
       houseItems: loadHouseItems(),
+      visitedHouseItems: [],
+      houseOwnerId: null,
+      houseOwnerName: null,
     })
 
     get().checkAchievements()
@@ -403,6 +418,63 @@ export const useGameStore = create<GameState>((set, get) => ({
     set({ houseItems: items })
   },
   setHouseEditMode: (enabled) => set({ houseEditMode: enabled }),
+  setVisitedHouse: (ownerId, ownerName, items) => set({
+    houseOwnerId: ownerId,
+    houseOwnerName: ownerName,
+    visitedHouseItems: items,
+  }),
+  visitHouse: (ownerId, ownerName) => set((state) => {
+    const roomsVisited = state.gameStats.roomsVisited.includes('house')
+      ? state.gameStats.roomsVisited
+      : [...state.gameStats.roomsVisited, 'house']
+    const newStats: GameStats = {
+      ...state.gameStats,
+      roomsVisited,
+      roomSwitches: state.gameStats.roomSwitches + 1,
+    }
+    saveStats(newStats)
+    return {
+      currentRoom: 'house',
+      houseOwnerId: ownerId,
+      houseOwnerName: ownerName,
+      visitedHouseItems: [],
+      houseEditMode: false,
+      playerX: 0,
+      playerZ: 0,
+      playerTargetX: 0,
+      playerTargetZ: 0,
+      playerChat: null,
+      playerEmote: null,
+      remotePlayers: {},
+      gameStats: newStats,
+    }
+  }),
+  enterOwnHouse: () => set((state) => {
+    const roomsVisited = state.gameStats.roomsVisited.includes('house')
+      ? state.gameStats.roomsVisited
+      : [...state.gameStats.roomsVisited, 'house']
+    const newStats: GameStats = {
+      ...state.gameStats,
+      roomsVisited,
+      roomSwitches: state.gameStats.roomSwitches + 1,
+    }
+    saveStats(newStats)
+    return {
+      currentRoom: 'house',
+      houseOwnerId: null,
+      houseOwnerName: null,
+      visitedHouseItems: [],
+      houseEditMode: false,
+      playerX: 0,
+      playerZ: 0,
+      playerTargetX: 0,
+      playerTargetZ: 0,
+      playerChat: null,
+      playerEmote: null,
+      remotePlayers: {},
+      gameStats: newStats,
+    }
+  }),
 
   // ── GitHub level ────────────────────────────────────────────────────
   setGithubLevel: (username, level, contributions) => {


### PR DESCRIPTION
## Summary
- fix house visits to open the selected friend's house instead of their current room
- sync the owner's furniture layout over realtime and isolate house presence by owner id
- hide edit controls while visiting and restore the friends modal in the HUD

## Validation
- node node_modules/typescript/bin/tsc --noEmit
- npm run lint